### PR TITLE
Test billing API endpoints and assoc. new DB function

### DIFF
--- a/src/__tests__/api/billing.test.ts
+++ b/src/__tests__/api/billing.test.ts
@@ -4,6 +4,8 @@ import server from '../../server';
 import { createVerifier } from '../../util/auth';
 import {
     billList,
+    mockEmailBills,
+    mockGenerateNewBills,
     mockGetBillList,
     mockGetThreshold,
     mockMarkBillPaid,
@@ -17,7 +19,6 @@ import {
 } from '../util/authMocks';
 import { Bill, WorkPointThreshold } from '../../typedefs/bill';
 import { mockGetMember } from './mocks/member';
-import * as billingUtil from '../../util/billing';
 import { mockGetMembershipList } from './mocks/membership';
 
 const TAG_ROOT = '/api/billing';
@@ -385,26 +386,6 @@ describe('POST /billing/', () => {
             emailedBill: '2022-03-21',
             curYearPaid: true,
         }];
-
-        const mockGenerateNewBills = jest
-            .spyOn(billingUtil, 'generateNewBills')
-            .mockImplementation(async (): Promise<Bill[]> => Promise.resolve([{
-                billId: 0,
-                generatedDate: '2022-03-21',
-                year: 2022,
-                amount: 100,
-                amountWithFee: 101,
-                membershipAdmin: 'Jimbus Gimbus',
-                membershipAdminEmail: 'em@il.com',
-                emailedBill: undefined,
-                curYearPaid: true,
-            }]));
-        const mockEmailBills = jest
-            .spyOn(billingUtil, 'emailBills')
-            .mockImplementation(async (generatedBills: Bill[]): Promise<Bill[]> => {
-                generatedBills.forEach((bill) => { bill.emailedBill = '2022-03-21'; });
-                return Promise.resolve(generatedBills);
-            });
 
         const res = await supertestServer.post(`${TAG_ROOT}/`).set('Authorization', 'Bearer admin');
         expect(res.status).toBe(201);

--- a/src/__tests__/api/billing.test.ts
+++ b/src/__tests__/api/billing.test.ts
@@ -1,32 +1,425 @@
+import _ from 'lodash';
 import supertest from 'supertest';
 import server from '../../server';
+import { createVerifier } from '../../util/auth';
+import {
+    billList,
+    mockGetBillList,
+    mockGetThreshold,
+    mockMarkBillPaid,
+} from './mocks/billing';
+import {
+    mockInvalidToken,
+    mockValidToken,
+    mockVerifyAdmin,
+    mockVerifyMember,
+    mockVerifyMembershipAdmin,
+} from '../util/authMocks';
+import { Bill, WorkPointThreshold } from '../../typedefs/bill';
+import { mockGetMember } from './mocks/member';
+import * as billingUtil from '../../util/billing';
+import { mockGetMembershipList } from './mocks/membership';
 
 const TAG_ROOT = '/api/billing';
 
 const supertestServer = supertest(server);
 
+beforeAll(() => {
+    createVerifier();
+});
+
 afterAll((done) => {
     server.close(done);
 });
 
-describe('All implemented (but untested) billing endpoints are reachable', () => {
-    it('GET /billing/yearlyWorkPointThreshold is reachable', async () => {
-        await supertestServer.get(`${TAG_ROOT}/yearlyWorkPointThreshold`);
+describe('GET /billing/yearlyWorkPointThreshold', () => {
+    it('Returns 500 on Internal Server Error', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/yearlyWorkPointThreshold`)
+            .set('Authorization', 'Bearer validtoken');
+        expect(mockValidToken).toHaveBeenCalled();
+        expect(mockGetThreshold).toHaveBeenCalled();
+        expect(res.status).toBe(500);
+        expect(res.body.reason).toBe('internal server error');
     });
 
-    it('GET /billing/list is reachable', async () => {
-        await supertestServer.get(`${TAG_ROOT}/list`);
+    it('Returns 401 for no token', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/yearlyWorkPointThreshold`);
+        expect(mockGetThreshold).not.toHaveBeenCalled();
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('Missing authorization grant in header');
     });
 
-    it('GET /billing/:id is reachable', async () => {
-        await supertestServer.get(`${TAG_ROOT}/42`);
+    it('Returns 401 for invalid token', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/yearlyWorkPointThreshold`)
+            .set('Authorization', 'Bearer invalidtoken');
+        expect(mockInvalidToken).toHaveBeenCalled();
+        expect(mockGetThreshold).not.toHaveBeenCalled();
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('not authorized');
     });
 
-    it('POST /billing/:id is reachable', async () => {
-        await supertestServer.post(`${TAG_ROOT}/42`);
+    it('Gets the default threshold without query', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/yearlyWorkPointThreshold`)
+            .set('Authorization', 'Bearer validtoken');
+        expect(mockValidToken).toHaveBeenCalled();
+        expect(mockGetThreshold).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const wpt: WorkPointThreshold = res.body;
+        expect(wpt.year).toEqual(new Date().getFullYear());
     });
 
-    it('POST /billing is reachable', async () => {
-        await supertestServer.post(`${TAG_ROOT}`);
+    it('Gets the default threshold with NaN query', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/yearlyWorkPointThreshold?year=bwahahaFearMeForIAmString`)
+            .set('Authorization', 'Bearer validtoken');
+        expect(mockValidToken).toHaveBeenCalled();
+        expect(mockGetThreshold).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const wpt: WorkPointThreshold = res.body;
+        expect(wpt.year).toEqual(new Date().getFullYear());
+    });
+
+    it('Gets the correct threshold with query', async () => {
+        const year = 1976;
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/yearlyWorkPointThreshold?year=${year}`)
+            .set('Authorization', 'Bearer validtoken');
+        expect(mockValidToken).toHaveBeenCalled();
+        expect(mockGetThreshold).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const wpt: WorkPointThreshold = res.body;
+        expect(wpt.year).toEqual(year);
+    });
+});
+
+describe('GET /billing/list', () => {
+    beforeAll(() => {
+        mockGetBillList.mockClear();
+    });
+
+    it('Returns 500 on Internal Server Error', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/list?paymentStatus=ise`)
+            .set('Authorization', 'Bearer admin');
+        expect(res.status).toBe(500);
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.body.reason).toBe('internal server error');
+    });
+
+    it('Returns 401 for no token', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/list`);
+        expect(mockGetBillList).not.toHaveBeenCalled();
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('Missing authorization grant in header');
+    });
+
+    it('Returns 401 for invalid token', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/list`).set('Authorization', 'Bearer invalidtoken');
+        expect(mockInvalidToken).toHaveBeenCalled();
+        expect(mockGetBillList).not.toHaveBeenCalled();
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('not authorized');
+    });
+
+    it('Returns 403 for insufficient permissions', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/list`).set('Authorization', 'Bearer member');
+        expect(mockVerifyMember).toHaveBeenCalled();
+        expect(mockVerifyAdmin).not.toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(res.status).toBe(403);
+        expect(res.body.reason).toBe('forbidden');
+    });
+
+    it('Gets the unfiltered list', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/list`).set('Authorization', 'Bearer admin');
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        expect(_.isEqual(result, billList)).toBeTruthy();
+    });
+
+    it('Correctly filters by paid status', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/list?paymentStatus=paid`)
+            .set('Authorization', 'Bearer admin');
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        result.forEach((b: Bill) => {
+            expect(b.curYearPaid).toBeTruthy();
+        });
+    });
+
+    it('Correctly filters by outstanding status', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/list?paymentStatus=outstanding`)
+            .set('Authorization', 'Bearer admin');
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        result.forEach((b: Bill) => {
+            expect(b.curYearPaid).toBeFalsy();
+        });
+    });
+
+    it('Correctly filters by incorrect status', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/list?paymentStatus=incorrect`)
+            .set('Authorization', 'Bearer admin');
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        expect(_.isEqual(result, billList)).toBeTruthy();
+    });
+
+    it('Correctly filters by year', async () => {
+        const year = 2022;
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/list?year=${year}`)
+            .set('Authorization', 'Bearer admin');
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        result.forEach((b: Bill) => {
+            expect(b.year).toBe(year);
+        });
+    });
+
+    it('Correctly ignores NaN year filter', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/list?year=incorrect`)
+            .set('Authorization', 'Bearer admin');
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        expect(_.isEqual(result, billList)).toBeTruthy();
+    });
+});
+
+describe('GET /billing/:membershipID', () => {
+    it('Returns 500 on Internal Server Error', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/500`)
+            .set('Authorization', 'Bearer membershipAdmin');
+        expect(res.status).toBe(500);
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.body.reason).toBe('internal server error');
+    });
+
+    it('Returns 401 for no token', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/0`);
+        expect(mockGetBillList).not.toHaveBeenCalled();
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('Missing authorization grant in header');
+    });
+
+    it('Returns 401 for invalid token', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/0`).set('Authorization', 'Bearer invalidtoken');
+        expect(mockInvalidToken).toHaveBeenCalled();
+        expect(mockGetBillList).not.toHaveBeenCalled();
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('not authorized');
+    });
+
+    it('Returns 403 for insufficient permissions', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/0`).set('Authorization', 'Bearer member');
+        expect(mockVerifyMember).toHaveBeenCalled();
+        expect(mockVerifyMembershipAdmin).not.toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(res.status).toBe(403);
+        expect(res.body.reason).toBe('forbidden');
+    });
+
+    it('Returns 404 for membershipId not found', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/9999`).set('Authorization', 'Bearer membershipAdmin');
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(404);
+        expect(res.body.reason).toBe('not found');
+    });
+
+    it('Returns 404 for NaN membershipId', async () => {
+        const res = await supertestServer
+            .get(`${TAG_ROOT}/Jimbus%20Gimbus`)
+            .set('Authorization', 'Bearer membershipAdmin');
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).not.toHaveBeenCalled();
+        expect(res.status).toBe(404);
+        expect(res.body.reason).toBe('not found');
+    });
+
+    it('Gets the list', async () => {
+        const res = await supertestServer.get(`${TAG_ROOT}/0`).set('Authorization', 'Bearer membershipAdmin');
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        const result: Bill[] = res.body;
+        result.forEach((b: Bill) => {
+            expect(b.membershipAdmin).toBe('Jimbus Gimbus');
+        });
+    });
+});
+
+describe('POST /billing/:membershipID', () => {
+    it('Returns 500 on internal server error', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/0`).set('Authorization', 'Bearer admin');
+        expect(res.status).toBe(500);
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockMarkBillPaid).toHaveBeenCalled();
+        expect(res.body.reason).toBe('internal server error');
+    });
+
+    it('Returns 401 for no token', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/0`);
+        expect(res.status).toBe(401);
+        expect(mockMarkBillPaid).not.toHaveBeenCalled();
+        expect(res.body.reason).toBe('Missing authorization grant in header');
+    });
+
+    it('Returns 401 for invalid token', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/0`).set('Authorization', 'Bearer invalidtoken');
+        expect(res.status).toBe(401);
+        expect(mockInvalidToken).toHaveBeenCalled();
+        expect(mockMarkBillPaid).not.toHaveBeenCalled();
+        expect(res.body.reason).toBe('not authorized');
+    });
+
+    it('Returns 403 for insufficient permissions', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/0`).set('Authorization', 'Bearer member');
+        expect(mockVerifyMember).toHaveBeenCalled();
+        expect(mockVerifyAdmin).not.toHaveBeenCalled();
+        expect(res.status).toBe(403);
+        expect(res.body.reason).toBe('forbidden');
+    });
+
+    it('Returns 404 for membershipID not found', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/9999`).set('Authorization', 'Bearer membershipAdmin');
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockMarkBillPaid).toHaveBeenCalled();
+        expect(res.status).toBe(404);
+        expect(res.body.reason).toBe('not found');
+    });
+
+    it('Returns 404 for NaN membershipID', async () => {
+        const res = await supertestServer
+            .post(`${TAG_ROOT}/Jimbus%20Gimbus`)
+            .set('Authorization', 'Bearer membershipAdmin');
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockMarkBillPaid).not.toHaveBeenCalled();
+        expect(res.status).toBe(404);
+        expect(res.body.reason).toBe('not found');
+    });
+
+    it('Marks a bill as paid', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/0`).set('Authorization', 'Bearer membershipAdmin');
+        expect(mockVerifyMembershipAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockMarkBillPaid).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+    });
+});
+
+describe('POST /billing/', () => {
+    it('Returns 500 on internal server error', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/`).set('Authorization', 'Bearer admin');
+        expect(res.status).toBe(500);
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetMembershipList).toHaveBeenCalled();
+        expect(res.body.reason).toBe('internal server error');
+    });
+
+    it('Returns 401 for no token', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/`);
+        expect(res.status).toBe(401);
+        expect(mockMarkBillPaid).not.toHaveBeenCalled();
+        expect(res.body.reason).toBe('Missing authorization grant in header');
+    });
+
+    it('Returns 401 for invalid token', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/`).set('Authorization', 'Bearer invalidtoken');
+        expect(res.status).toBe(401);
+        expect(mockInvalidToken).toHaveBeenCalled();
+        expect(mockMarkBillPaid).not.toHaveBeenCalled();
+        expect(res.body.reason).toBe('not authorized');
+    });
+
+    it('Returns 403 for insufficient permissions', async () => {
+        const res = await supertestServer.post(`${TAG_ROOT}/`).set('Authorization', 'Bearer member');
+        expect(mockVerifyMember).toHaveBeenCalled();
+        expect(mockVerifyAdmin).not.toHaveBeenCalled();
+        expect(res.status).toBe(403);
+        expect(res.body.reason).toBe('forbidden');
+    });
+
+    it('Generates all-new bills', async () => {
+        const expResult = [{
+            billId: 0,
+            generatedDate: '2022-03-21',
+            year: 2022,
+            amount: 100,
+            amountWithFee: 101,
+            membershipAdmin: 'Jimbus Gimbus',
+            membershipAdminEmail: 'em@il.com',
+            emailedBill: '2022-03-21',
+            curYearPaid: true,
+        }];
+
+        const mockGenerateNewBills = jest
+            .spyOn(billingUtil, 'generateNewBills')
+            .mockImplementation(async (): Promise<Bill[]> => Promise.resolve([{
+                billId: 0,
+                generatedDate: '2022-03-21',
+                year: 2022,
+                amount: 100,
+                amountWithFee: 101,
+                membershipAdmin: 'Jimbus Gimbus',
+                membershipAdminEmail: 'em@il.com',
+                emailedBill: undefined,
+                curYearPaid: true,
+            }]));
+        const mockEmailBills = jest
+            .spyOn(billingUtil, 'emailBills')
+            .mockImplementation(async (generatedBills: Bill[]): Promise<Bill[]> => {
+                generatedBills.forEach((bill) => { bill.emailedBill = '2022-03-21'; });
+                return Promise.resolve(generatedBills);
+            });
+
+        const res = await supertestServer.post(`${TAG_ROOT}/`).set('Authorization', 'Bearer admin');
+        expect(res.status).toBe(201);
+        expect(mockVerifyAdmin).toHaveBeenCalled();
+        expect(mockGetMember).toHaveBeenCalled();
+        expect(mockGetMembershipList).toHaveBeenCalled();
+        expect(mockGetThreshold).toHaveBeenCalled();
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(mockGenerateNewBills).toHaveBeenCalled();
+        expect(mockEmailBills).toHaveBeenCalled();
+        const result: Bill[] = res.body;
+        expect(_.isEqual(result, expResult)).toBeTruthy();
     });
 });

--- a/src/__tests__/api/billing.test.ts
+++ b/src/__tests__/api/billing.test.ts
@@ -96,10 +96,6 @@ describe('GET /billing/yearlyWorkPointThreshold', () => {
 });
 
 describe('GET /billing/list', () => {
-    beforeAll(() => {
-        mockGetBillList.mockClear();
-    });
-
     it('Returns 500 on Internal Server Error', async () => {
         const res = await supertestServer
             .get(`${TAG_ROOT}/list?paymentStatus=ise`)

--- a/src/__tests__/api/mocks/billing.ts
+++ b/src/__tests__/api/mocks/billing.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { Bill, GetBillListRequestFilters, WorkPointThreshold } from 'src/typedefs/bill';
 import { Membership } from 'src/typedefs/membership';
 import * as billing from '../../../database/billing';
+import * as billingUtil from '../../../util/billing';
 
 export const billList: Bill[] = [
     {
@@ -151,3 +152,24 @@ export const membershipList: Membership[] = [
         lastModifiedBy: 'Lurge Geocas',
     },
 ];
+
+export const mockGenerateNewBills = jest
+    .spyOn(billingUtil, 'generateNewBills')
+    .mockImplementation(async (): Promise<Bill[]> => Promise.resolve([{
+        billId: 0,
+        generatedDate: '2022-03-21',
+        year: 2022,
+        amount: 100,
+        amountWithFee: 101,
+        membershipAdmin: 'Jimbus Gimbus',
+        membershipAdminEmail: 'em@il.com',
+        emailedBill: undefined,
+        curYearPaid: true,
+    }]));
+
+export const mockEmailBills = jest
+    .spyOn(billingUtil, 'emailBills')
+    .mockImplementation(async (generatedBills: Bill[]): Promise<Bill[]> => {
+        generatedBills.forEach((bill) => { bill.emailedBill = '2022-03-21'; });
+        return Promise.resolve(generatedBills);
+    });

--- a/src/__tests__/api/mocks/billing.ts
+++ b/src/__tests__/api/mocks/billing.ts
@@ -1,0 +1,153 @@
+import _ from 'lodash';
+import { Bill, GetBillListRequestFilters, WorkPointThreshold } from 'src/typedefs/bill';
+import { Membership } from 'src/typedefs/membership';
+import * as billing from '../../../database/billing';
+
+export const billList: Bill[] = [
+    {
+        billId: 0,
+        generatedDate: '2022-03-21',
+        year: 2022,
+        amount: 100,
+        amountWithFee: 101,
+        membershipAdmin: 'Jimbus Gimbus',
+        membershipAdminEmail: 'em@il.com',
+        emailedBill: '2022-03-21',
+        curYearPaid: true,
+    }, {
+        billId: 1,
+        generatedDate: '2022-03-21',
+        year: 2022,
+        amount: 100,
+        amountWithFee: 101,
+        membershipAdmin: 'Rando Mando',
+        membershipAdminEmail: 'em@il.com',
+        emailedBill: '2022-03-21',
+        curYearPaid: false,
+    }, {
+        billId: 2,
+        generatedDate: '2022-03-21',
+        year: 2021,
+        amount: 100,
+        amountWithFee: 101,
+        membershipAdmin: 'Jimbus Gimbus',
+        membershipAdminEmail: 'em@il.com',
+        emailedBill: '2022-03-21',
+        curYearPaid: false,
+    }, {
+        billId: 3,
+        generatedDate: '2022-03-21',
+        year: 2021,
+        amount: 100,
+        amountWithFee: 101,
+        membershipAdmin: 'Rando Mando',
+        membershipAdminEmail: 'em@il.com',
+        emailedBill: '2022-03-21',
+        curYearPaid: true,
+    },
+];
+
+export const mockGetBillList = jest
+    .spyOn(billing, 'getBillList')
+    .mockImplementation((filters: GetBillListRequestFilters): Promise<Bill[]> => {
+        let bills: Bill[] = billList;
+        const { membershipId, year, paymentStatus } = filters;
+        if (typeof membershipId !== 'undefined') {
+            let targetAdmin: string;
+            if (membershipId === 0) {
+                targetAdmin = 'Jimbus Gimbus';
+            } else if (membershipId === 1) {
+                targetAdmin = 'Rando Mando';
+            } else if (membershipId === 500) {
+                throw new Error('internal server error');
+            } else {
+                // shouldn't have any bills
+                targetAdmin = 'Philbert Zilbert';
+            }
+            bills = _.filter(bills, (bill) => bill.membershipAdmin === targetAdmin);
+        }
+        if (typeof year !== 'undefined') {
+            bills = _.filter(bills, (bill) => bill.year === Number(year));
+        }
+        if (typeof paymentStatus !== 'undefined') {
+            switch (paymentStatus) {
+                case 'paid':
+                    bills = _.filter(bills, (bill) => bill.curYearPaid);
+                    break;
+                case 'outstanding':
+                    bills = _.filter(bills, (bill) => !bill.curYearPaid);
+                    break;
+                case 'ise':
+                    throw new Error('internal server error');
+                default:
+                    // don't filter
+            }
+        }
+        return Promise.resolve(bills);
+    });
+
+export const mockGetThreshold = jest.spyOn(billing, 'getWorkPointThreshold').mockImplementationOnce(() => {
+    throw new Error('internal server error');
+}).mockImplementation((year: number): Promise<WorkPointThreshold> => {
+    const curYear = new Date().getFullYear();
+    switch (year) {
+        case curYear:
+            return Promise.resolve({ year: curYear, threshold: 100 });
+        case 1976:
+            return Promise.resolve({ year: 1976, threshold: 100 });
+        default:
+            throw new Error('not found');
+    }
+});
+
+export const mockMarkBillPaid = jest.spyOn(billing, 'markBillPaid').mockImplementationOnce(() => {
+    throw new Error('internal server error');
+}).mockImplementation((id: number): Promise<void> => {
+    if (id !== 0) {
+        throw new Error('not found');
+    }
+    return Promise.resolve();
+});
+
+export const membershipList: Membership[] = [
+    {
+        membershipId: 0,
+        membershipAdmin: 'Criminy Jicket',
+        status: 'Active',
+        curYearRenewed: true,
+        renewalSent: true,
+        yearJoined: 2022,
+        address: 'the ground',
+        city: 'or wherever',
+        state: 'jickets',
+        zip: 'live',
+        lastModifiedDate: '2022-03-09',
+        lastModifiedBy: 'Nipocchio',
+    }, {
+        membershipId: 1,
+        membershipAdmin: 'Gilgo Gabbins',
+        status: 'Active',
+        curYearRenewed: true,
+        renewalSent: true,
+        yearJoined: 2022,
+        address: 'his house',
+        city: 'the shire',
+        state: 'uhhh the shire',
+        zip: "what's a zip",
+        lastModifiedDate: '2022-03-09',
+        lastModifiedBy: 'Dangalf',
+    }, {
+        membershipId: 2,
+        membershipAdmin: 'Skykin Anawalker',
+        status: 'Active',
+        curYearRenewed: true,
+        renewalSent: true,
+        yearJoined: 2022,
+        address: 'right off a lava river',
+        city: 'the low ground',
+        state: 'mustafar',
+        zip: '¯\\_(ツ)_/¯',
+        lastModifiedDate: '2022-03-09',
+        lastModifiedBy: 'Lurge Geocas',
+    },
+];

--- a/src/__tests__/database/server/membership.test.ts
+++ b/src/__tests__/database/server/membership.test.ts
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 import { PatchMembershipRequest } from 'src/typedefs/membership';
 import {
+    getBaseDues,
     getMembership,
     getMembershipList,
     getRegistration,
@@ -283,6 +284,28 @@ describe('getRegistration()', () => {
     it('Throws for internal server error', async () => {
         const registrationId = -100;
         await expect(getRegistration(registrationId)).rejects.toThrow('internal server error');
+        expect(mockQuery).toHaveBeenCalled();
+    });
+});
+
+describe('getBaseDues()', () => {
+    it('Selects a single membership', async () => {
+        const membershipId = 18;
+
+        const result = await getBaseDues(membershipId);
+        expect(mockQuery).toHaveBeenCalled();
+        expect(result).toBe(500);
+    });
+
+    it('Throws for membership not found', async () => {
+        const membershipId = 765;
+        await expect(getBaseDues(membershipId)).rejects.toThrow('not found');
+        expect(mockQuery).toHaveBeenCalled();
+    });
+
+    it('Throws for internal server error', async () => {
+        const membershipId = -100;
+        await expect(getBaseDues(membershipId)).rejects.toThrow('internal server error');
         expect(mockQuery).toHaveBeenCalled();
     });
 });

--- a/src/__tests__/database/server/mockHelpers/membership.ts
+++ b/src/__tests__/database/server/mockHelpers/membership.ts
@@ -191,3 +191,16 @@ export function getRegistrationResponse(memberId: number) {
             return Promise.resolve();
     }
 }
+
+export function getBaseDuesResponse(id: number) {
+    switch (id) {
+        case 18:
+            return Promise.resolve([[{ base_dues_amt: 500 }]]);
+        case 765:
+            return Promise.resolve([[]]);
+        case -100:
+            throw new Error('error message');
+        default:
+            return Promise.resolve();
+    }
+}

--- a/src/__tests__/database/server/mockQuery.ts
+++ b/src/__tests__/database/server/mockQuery.ts
@@ -26,6 +26,7 @@ import {
     DELETE_EVENT_SQL,
 } from '../../../database/event';
 import {
+    GET_BASE_DUES_SQL,
     GET_MEMBERSHIP_LIST_BY_STATUS_SQL,
     GET_MEMBERSHIP_LIST_SQL,
     GET_MEMBERSHIP_SQL,
@@ -143,6 +144,8 @@ const mockQueryImplementation = async (sql: QueryOptions, values: any): Promise<
             return membershipHelpers.getRegisteredMemberIdResponse();
         case GET_REGISTRATION_SQL:
             return membershipHelpers.getRegistrationResponse(values[0]);
+        case GET_BASE_DUES_SQL:
+            return membershipHelpers.getBaseDuesResponse(values[0]);
         case GET_WORK_POINTS_BY_MEMBER_SQL:
             return getWorkPointsByMemberResponse(values);
         case GET_WORK_POINTS_BY_MEMBERSHIP_SQL:

--- a/src/__tests__/util/billing.test.ts
+++ b/src/__tests__/util/billing.test.ts
@@ -219,6 +219,7 @@ describe('generateNewBills()', () => {
     });
 });
 
+// TODO: un-skip this when emailing bills is implemented
 describe.skip('emailBills()', () => {
     it('Emails bills correctly', async () => {
         const generatedBills = [{

--- a/src/__tests__/util/billing.test.ts
+++ b/src/__tests__/util/billing.test.ts
@@ -1,0 +1,291 @@
+import { format } from 'date-fns';
+import { Bill } from '../../typedefs/bill';
+import { WorkPoints } from '../../typedefs/workPoints';
+import { mockGetBillList } from '../api/mocks/billing';
+import { generateNewBills, emailBills } from '../../util/billing';
+import * as billing from '../../database/billing';
+import * as dbMembership from '../../database/membership';
+import * as dbWorkPoints from '../../database/workPoints';
+
+export const mockGenerateBill = jest.spyOn(billing, 'generateBill').mockImplementation();
+
+export const mockMarkBillEmailed = jest.spyOn(billing, 'markBillEmailed').mockImplementation();
+
+describe('generateNewBills()', () => {
+    it('Calculates nonzero bill amount and fee correctly', async () => {
+        const membershipId = 0;
+        const membershipList = [{
+            membershipId,
+            membershipAdmin: 'Criminy Jicket',
+            status: 'Active',
+            curYearRenewed: true,
+            renewalSent: true,
+            yearJoined: 2022,
+            address: 'the ground',
+            city: 'or wherever',
+            state: 'jickets',
+            zip: 'live',
+            lastModifiedDate: '2022-03-09',
+            lastModifiedBy: 'Nipocchio',
+        }];
+        const preGeneratedBills: Bill[] = [];
+        const year = new Date().getFullYear();
+        const threshold = 100;
+        const baseDues = 1000;
+        const earned = 25;
+        const expOwed = 750;
+        const expOwedWithFee = 750; // TODO: change if fee is added
+
+        const mockGetBaseDues = jest
+            .spyOn(dbMembership, 'getBaseDues')
+            .mockImplementation(async (): Promise<number> => baseDues);
+        const mockGetWorkPointsByMembership = jest
+            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
+
+        // ignore the output from generateNewBills because mockGetBillList will
+        // return an inaccurate list
+        await generateNewBills(membershipList, preGeneratedBills, threshold, year);
+        expect(mockGetBaseDues).toHaveBeenCalled();
+        expect(mockGetWorkPointsByMembership).toHaveBeenCalled();
+        expect(mockGenerateBill).toHaveBeenCalledWith({
+            amount: expOwed,
+            amountWithFee: expOwedWithFee,
+            membershipId,
+        });
+        expect(mockGetBillList).toHaveBeenCalled();
+    });
+
+    it('Calculates paid-off bill amount and fee correctly', async () => {
+        const membershipId = 0;
+        const membershipList = [{
+            membershipId,
+            membershipAdmin: 'Criminy Jicket',
+            status: 'Active',
+            curYearRenewed: true,
+            renewalSent: true,
+            yearJoined: 2022,
+            address: 'the ground',
+            city: 'or wherever',
+            state: 'jickets',
+            zip: 'live',
+            lastModifiedDate: '2022-03-09',
+            lastModifiedBy: 'Nipocchio',
+        }];
+        const preGeneratedBills: Bill[] = [];
+        const year = new Date().getFullYear();
+        const threshold = 100;
+        const baseDues = 1000;
+        const earned = 125;
+        const expOwed = 0;
+        const expOwedWithFee = 0; // TODO: change if fee is added
+
+        const mockGetBaseDues = jest
+            .spyOn(dbMembership, 'getBaseDues')
+            .mockImplementation(async (): Promise<number> => baseDues);
+        const mockGetWorkPointsByMembership = jest
+            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
+
+        // ignore the output from generateNewBills because mockGetBillList will
+        // return an inaccurate list
+        await generateNewBills(membershipList, preGeneratedBills, threshold, year);
+        expect(mockGetBaseDues).toHaveBeenCalled();
+        expect(mockGetWorkPointsByMembership).toHaveBeenCalled();
+        expect(mockGenerateBill).toHaveBeenCalledWith({
+            amount: expOwed,
+            amountWithFee: expOwedWithFee,
+            membershipId,
+        });
+        expect(mockGetBillList).toHaveBeenCalled();
+    });
+
+    it('Does not generate duplicate bills', async () => {
+        const membershipList = [{
+            membershipId: 0,
+            membershipAdmin: 'Jimbus Gimbus',
+            status: 'Active',
+            curYearRenewed: true,
+            renewalSent: true,
+            yearJoined: 2022,
+            address: '...',
+            city: '...',
+            state: '...',
+            zip: '...',
+            lastModifiedDate: '...',
+            lastModifiedBy: '...',
+        }, {
+            membershipId: 1,
+            membershipAdmin: 'Rando Mando',
+            status: 'Active',
+            curYearRenewed: true,
+            renewalSent: true,
+            yearJoined: 2022,
+            address: '...',
+            city: '...',
+            state: '...',
+            zip: '...',
+            lastModifiedDate: '...',
+            lastModifiedBy: '...',
+        }];
+        const preGeneratedBills: Bill[] = [{
+            billId: 1,
+            generatedDate: '2022-03-21',
+            year: 2022,
+            amount: 100,
+            amountWithFee: 101,
+            membershipAdmin: 'Rando Mando',
+            membershipAdminEmail: 'em@il.com',
+            emailedBill: '2022-03-21',
+            curYearPaid: false,
+        }];
+        const year = new Date().getFullYear();
+        const threshold = 100;
+        const baseDues = 1000;
+        const earned = 125;
+
+        const mockGetBaseDues = jest
+            .spyOn(dbMembership, 'getBaseDues')
+            .mockImplementation(async (): Promise<number> => baseDues);
+        const mockGetWorkPointsByMembership = jest
+            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
+
+        const results = await generateNewBills(membershipList, preGeneratedBills, threshold, year);
+        expect(mockGetBaseDues).toHaveBeenCalled();
+        expect(mockGetWorkPointsByMembership).toHaveBeenCalled();
+        expect(mockGenerateBill).toHaveBeenCalledTimes(1);
+        expect(mockGetBillList).toHaveBeenCalled();
+        expect(results.length).toBe(1);
+        expect(results[0].membershipAdmin).toBe('Jimbus Gimbus');
+    });
+
+    it('Does not short-circuit upon bill generation error', async () => {
+        const membershipList = [{
+            membershipId: 0,
+            membershipAdmin: 'Jimbus Gimbus',
+            status: 'Active',
+            curYearRenewed: true,
+            renewalSent: true,
+            yearJoined: 2022,
+            address: '...',
+            city: '...',
+            state: '...',
+            zip: '...',
+            lastModifiedDate: '...',
+            lastModifiedBy: '...',
+        }, {
+            membershipId: 1,
+            membershipAdmin: 'Rando Mando',
+            status: 'Active',
+            curYearRenewed: true,
+            renewalSent: true,
+            yearJoined: 2022,
+            address: '...',
+            city: '...',
+            state: '...',
+            zip: '...',
+            lastModifiedDate: '...',
+            lastModifiedBy: '...',
+        }];
+        const preGeneratedBills: Bill[] = [];
+        const year = new Date().getFullYear();
+        const threshold = 100;
+        const baseDues = 1000;
+        const earned = 125;
+
+        const mockGetBaseDues = jest
+            .spyOn(dbMembership, 'getBaseDues')
+            .mockImplementationOnce(() => { throw new Error('intentional test design'); })
+            .mockImplementation(async (): Promise<number> => baseDues);
+        const mockGetWorkPointsByMembership = jest
+            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
+
+        // ignore the output from generateNewBills because mockGetBillList will
+        // return an inaccurate list
+        await generateNewBills(membershipList, preGeneratedBills, threshold, year);
+        // track passage through the loop by counting mock calls
+        expect(mockGetBaseDues).toHaveBeenCalledTimes(2);
+        // these should only be called the second time through
+        expect(mockGetWorkPointsByMembership).toHaveBeenCalledTimes(1);
+        expect(mockGenerateBill).toHaveBeenCalledTimes(1);
+        expect(mockGetBillList).toHaveBeenCalled();
+    });
+});
+
+describe.skip('emailBills()', () => {
+    it('Emails bills correctly', async () => {
+        const generatedBills = [{
+            billId: 0,
+            generatedDate: '2022-03-21',
+            year: 2022,
+            amount: 100,
+            amountWithFee: 101,
+            membershipAdmin: 'Jimbus Gimbus',
+            membershipAdminEmail: 'em@il.com',
+            emailedBill: undefined,
+            curYearPaid: true,
+        }];
+        const today = format(new Date(), 'yyyy-MM-dd');
+
+        // TODO: probably gonna need additional mock(s) here
+        const results = await emailBills(generatedBills);
+        expect(mockMarkBillEmailed).toHaveBeenCalled();
+        expect(results[0].emailedBill).toBe(today);
+    });
+
+    it('Does not send duplicate emails', async () => {
+        const generatedBills = [{
+            billId: 0,
+            generatedDate: '2022-03-21',
+            year: 2022,
+            amount: 100,
+            amountWithFee: 101,
+            membershipAdmin: 'Jimbus Gimbus',
+            membershipAdminEmail: 'em@il.com',
+            emailedBill: '2022-03-21',
+            curYearPaid: true,
+        }];
+
+        // TODO: probably gonna need additional mock(s) here
+        const results = await emailBills(generatedBills);
+        expect(mockMarkBillEmailed).not.toHaveBeenCalled();
+        expect(results[0].emailedBill).toBe('2022-03-21');
+    });
+
+    it('Does not short-circuit upon email send error', async () => {
+        const generatedBills = [{
+            billId: 0,
+            generatedDate: '2022-03-21',
+            year: 2022,
+            amount: 100,
+            amountWithFee: 101,
+            membershipAdmin: 'Jimbus Gimbus',
+            membershipAdminEmail: 'em@il.com',
+            emailedBill: undefined,
+            curYearPaid: true,
+        }, {
+            billId: 1,
+            generatedDate: '2022-03-21',
+            year: 2022,
+            amount: 100,
+            amountWithFee: 101,
+            membershipAdmin: 'Rando Mando',
+            membershipAdminEmail: 'em@il.com',
+            emailedBill: undefined,
+            curYearPaid: false,
+        }];
+        const today = format(new Date(), 'yyyy-MM-dd');
+
+        // TODO: make a mock that throws error the first time and works the second
+        // (see the generateNewBills() no-short-circuit test)
+        const results = await emailBills(generatedBills);
+        // TODO: expect that mock to be called twice
+
+        // this should only be called the second time through
+        expect(mockMarkBillEmailed).toHaveBeenCalledTimes(1);
+        expect(results[0].emailedBill).toBeUndefined();
+        expect(results[1].emailedBill).toBe(today);
+    });
+});

--- a/src/__tests__/util/billing.test.ts
+++ b/src/__tests__/util/billing.test.ts
@@ -1,15 +1,20 @@
 import { format } from 'date-fns';
 import { Bill } from '../../typedefs/bill';
 import { WorkPoints } from '../../typedefs/workPoints';
-import { mockGetBillList } from '../api/mocks/billing';
+import { mockEmailBills, mockGenerateNewBills, mockGetBillList } from '../api/mocks/billing';
 import { generateNewBills, emailBills } from '../../util/billing';
 import * as billing from '../../database/billing';
-import * as dbMembership from '../../database/membership';
-import * as dbWorkPoints from '../../database/workPoints';
+import * as membership from '../../database/membership';
+import * as workPoints from '../../database/workPoints';
 
 export const mockGenerateBill = jest.spyOn(billing, 'generateBill').mockImplementation();
 
 export const mockMarkBillEmailed = jest.spyOn(billing, 'markBillEmailed').mockImplementation();
+
+beforeAll(() => {
+    mockGenerateNewBills.mockRestore();
+    mockEmailBills.mockRestore();
+});
 
 describe('generateNewBills()', () => {
     it('Calculates nonzero bill amount and fee correctly', async () => {
@@ -37,10 +42,10 @@ describe('generateNewBills()', () => {
         const expOwedWithFee = 750; // TODO: change if fee is added
 
         const mockGetBaseDues = jest
-            .spyOn(dbMembership, 'getBaseDues')
+            .spyOn(membership, 'getBaseDues')
             .mockImplementation(async (): Promise<number> => baseDues);
         const mockGetWorkPointsByMembership = jest
-            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .spyOn(workPoints, 'getWorkPointsByMembership')
             .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
 
         // ignore the output from generateNewBills because mockGetBillList will
@@ -81,10 +86,10 @@ describe('generateNewBills()', () => {
         const expOwedWithFee = 0; // TODO: change if fee is added
 
         const mockGetBaseDues = jest
-            .spyOn(dbMembership, 'getBaseDues')
+            .spyOn(membership, 'getBaseDues')
             .mockImplementation(async (): Promise<number> => baseDues);
         const mockGetWorkPointsByMembership = jest
-            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .spyOn(workPoints, 'getWorkPointsByMembership')
             .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
 
         // ignore the output from generateNewBills because mockGetBillList will
@@ -145,10 +150,10 @@ describe('generateNewBills()', () => {
         const earned = 125;
 
         const mockGetBaseDues = jest
-            .spyOn(dbMembership, 'getBaseDues')
+            .spyOn(membership, 'getBaseDues')
             .mockImplementation(async (): Promise<number> => baseDues);
         const mockGetWorkPointsByMembership = jest
-            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .spyOn(workPoints, 'getWorkPointsByMembership')
             .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
 
         const results = await generateNewBills(membershipList, preGeneratedBills, threshold, year);
@@ -195,11 +200,11 @@ describe('generateNewBills()', () => {
         const earned = 125;
 
         const mockGetBaseDues = jest
-            .spyOn(dbMembership, 'getBaseDues')
+            .spyOn(membership, 'getBaseDues')
             .mockImplementationOnce(() => { throw new Error('intentional test design'); })
             .mockImplementation(async (): Promise<number> => baseDues);
         const mockGetWorkPointsByMembership = jest
-            .spyOn(dbWorkPoints, 'getWorkPointsByMembership')
+            .spyOn(workPoints, 'getWorkPointsByMembership')
             .mockImplementation(async (): Promise<WorkPoints> => ({ total: earned }));
 
         // ignore the output from generateNewBills because mockGetBillList will

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -1,10 +1,9 @@
 import { Request, Response, Router } from 'express';
 import _ from 'lodash';
 // import { format } from 'date-fns';
-import { getBaseDues, getMembershipList } from '../database/membership';
-import { getWorkPointsByMembership } from '../database/workPoints';
+import { getMembershipList } from '../database/membership';
 import logger from '../logger';
-import { generateBill, getBillList, getWorkPointThreshold, markBillPaid } from '../database/billing';
+import { getBillList, getWorkPointThreshold, markBillPaid } from '../database/billing';
 import {
     Bill,
     GetBillListResponse,
@@ -14,12 +13,13 @@ import {
     PostPayBillResponse,
 } from '../typedefs/bill';
 import { checkHeader, verify } from '../util/auth';
+import { emailBills, generateNewBills } from '../util/billing';
 
 //
-// TODO: Emails are not sent for generated bills (line 206)
+// TODO: Emails are not sent for generated bills (see emailBills helper function in util)
 // (also uncomment the import on line 3)
 //
-// TODO: No fee calculated for bills (line 190)
+// TODO: No fee calculated for bills (see generateNewBills helper function in util)
 //
 
 const billing = Router();
@@ -69,10 +69,7 @@ billing.get('/list', async (req: Request, res: Response) => {
             res.status(200);
             response = billingList;
         } catch (e: any) {
-            if (e.message === 'user input error') {
-                res.status(400);
-                response = { reason: 'bad request' };
-            } else if (e.message === 'Authorization Failed') {
+            if (e.message === 'Authorization Failed') {
                 res.status(401);
                 response = { reason: 'not authorized' };
             } else if (e.message === 'Forbidden') {
@@ -101,7 +98,13 @@ billing.get('/:membershipID', async (req: Request, res: Response) => {
             if (Number.isNaN(membershipId)) {
                 throw new Error('not found');
             }
-            response = await getBillList({ membershipId });
+
+            const results = await getBillList({ membershipId });
+            if (_.isEmpty(results)) {
+                throw new Error('not found');
+            }
+
+            response = results;
             res.status(200);
         } catch (e: any) {
             if (e.message === 'Authorization Failed') {
@@ -122,7 +125,7 @@ billing.get('/:membershipID', async (req: Request, res: Response) => {
     res.send(response);
 });
 
-billing.post('/new', async (req: Request, res: Response) => {
+billing.post('/:membershipID', async (req: Request, res: Response) => {
     const { authorization } = req.headers;
     let response: PostPayBillResponse;
     const headerCheck = checkHeader(authorization);
@@ -169,54 +172,18 @@ billing.post('/', async (req: Request, res: Response) => {
         try {
             await verify(headerCheck.token, 'Admin');
             const curYear = new Date().getFullYear();
+            logger.info('getMembershipList');
             const membershipList = await getMembershipList('active');
+            logger.info('getWorkPointThreshold');
             const { threshold } = await getWorkPointThreshold(curYear);
             // to protect against generating duplicate bills
+            logger.info('getBillList');
             const preGeneratedBills = await getBillList({ year: curYear });
 
-            // generate new bills for each active membership
-            membershipList.forEach(async (membership) => {
-                // only generate a bill if one hasn't already been generated
-                if (typeof _.find(
-                    preGeneratedBills,
-                    (bill) => bill.membershipAdmin === membership.membershipAdmin,
-                ) === 'undefined') {
-                    try {
-                        const baseDues = await getBaseDues(membership.membershipId);
-                        const earned = (await getWorkPointsByMembership(membership.membershipId, curYear)).total;
-                        const owed = (1 - earned / threshold) * baseDues;
-                        await generateBill({
-                            amount: owed,
-                            amountWithFee: owed, // TODO: what's the fee?
-                            membershipId: membership.membershipId,
-                        });
-                    } catch (e) {
-                        // generate more bills even if this one failed
-                        logger.error(`Failed to generate bill for membership with ID ${membership.membershipId}: ${e}`);
-                    }
-                }
-            });
-
-            // all bills have been generated, so now email all of them
-            const generatedBills = await getBillList({ year: curYear });
-            generatedBills.forEach(async (bill) => {
-                // prevent sending duplicate emails for pre-generated bills
-                if (typeof bill.emailedBill === 'undefined') {
-                    try {
-                        //
-                        // TODO: send the email
-                        //
-                        // // (gonna need to import this fn from '../database/billing')
-                        // await markBillEmailed(bill.billId);
-                        // // update our local copy of the bill
-                        // bill.emailedBill = format(new Date(), 'yyyy-MM-dd');
-                        throw new Error('sending emails is unimplemented!');
-                    } catch (e) {
-                        // send more emails even if this one failed
-                        logger.error(`Failed to email bill ${bill.billId} to ${bill.membershipAdminEmail}: ${e}`);
-                    }
-                }
-            });
+            logger.info('generateNewBills');
+            let generatedBills = await generateNewBills(membershipList, preGeneratedBills, threshold, curYear);
+            logger.info('emailBills');
+            generatedBills = await emailBills(generatedBills);
 
             res.status(201);
             response = generatedBills;

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -2,7 +2,6 @@ import { Request, Response, Router } from 'express';
 import _ from 'lodash';
 // import { format } from 'date-fns';
 import { getMembershipList } from '../database/membership';
-import logger from '../logger';
 import { getBillList, getWorkPointThreshold, markBillPaid } from '../database/billing';
 import {
     Bill,
@@ -172,17 +171,12 @@ billing.post('/', async (req: Request, res: Response) => {
         try {
             await verify(headerCheck.token, 'Admin');
             const curYear = new Date().getFullYear();
-            logger.info('getMembershipList');
             const membershipList = await getMembershipList('active');
-            logger.info('getWorkPointThreshold');
             const { threshold } = await getWorkPointThreshold(curYear);
             // to protect against generating duplicate bills
-            logger.info('getBillList');
             const preGeneratedBills = await getBillList({ year: curYear });
 
-            logger.info('generateNewBills');
             let generatedBills = await generateNewBills(membershipList, preGeneratedBills, threshold, curYear);
-            logger.info('emailBills');
             generatedBills = await emailBills(generatedBills);
 
             res.status(201);

--- a/src/typedefs/bill.ts
+++ b/src/typedefs/bill.ts
@@ -8,7 +8,7 @@ export type Bill = {
     amountWithFee: number,
     membershipAdmin: string,
     membershipAdminEmail: string,
-    emailedBill: string,
+    emailedBill?: string, // undefined if not emailed, date otherwise
     curYearPaid: boolean
 }
 

--- a/src/util/billing.ts
+++ b/src/util/billing.ts
@@ -1,0 +1,93 @@
+import _ from 'lodash';
+import { generateBill, getBillList } from '../database/billing';
+import { getBaseDues } from '../database/membership';
+import { getWorkPointsByMembership } from '../database/workPoints';
+import logger from '../logger';
+import { Bill } from '../typedefs/bill';
+import { Membership } from '../typedefs/membership';
+
+/**
+ * Generate new bills in the database
+ *
+ * Note that an error generating a bill **does not** short-circuit the loop. The
+ * function will create all the bills it can.
+ *
+ * (Extracted into helper function to ease testing)
+ *
+ * @param membershipList A bill is generated for each membership in this list
+ * @param preGeneratedBills Any preexisting bills for the specified year so that
+ * duplicate bills are not created
+ * @param threshold The work point threshold for the specified year
+ * @param year The year to generate bills for
+ * @returns A list of *only* the bills that were just generated (does not
+ * include preexisting bills)
+ */
+export async function generateNewBills(
+    membershipList: Membership[],
+    preGeneratedBills: Bill[],
+    threshold: number,
+    year: number,
+): Promise<Bill[]> {
+    membershipList.forEach(async (membership) => {
+        // only generate a bill if one hasn't already been generated
+        if (typeof _.find(
+            preGeneratedBills,
+            (bill) => bill.membershipAdmin === membership.membershipAdmin,
+        ) === 'undefined') {
+            try {
+                const baseDues = await getBaseDues(membership.membershipId);
+                const earned = (await getWorkPointsByMembership(membership.membershipId, year)).total;
+                const owed = Math.max((1 - earned / threshold) * baseDues, 0);
+                await generateBill({
+                    amount: owed,
+                    amountWithFee: owed, // TODO: what's the fee?
+                    membershipId: membership.membershipId,
+                });
+            } catch (e) {
+                // generate more bills even if this one failed
+                logger.error(`Failed to generate bill for membership with ID ${membership.membershipId}: ${e}`);
+            }
+        }
+    });
+    const allBills = await getBillList({ year });
+    return _.differenceWith(allBills, preGeneratedBills, _.isEqual);
+}
+
+/**
+ * Email out all bills in the given list
+ *
+ * Ostensibly, none of the bills should have been emailed yet, but this function
+ * protects against duplicate emails anyway.
+ *
+ * Note that an error emailing a bill **does not** short-circuit the loop. The
+ * function will email all the bills it can.
+ *
+ * (Extracted into helper function to ease testing)
+ *
+ * @param billList The list of all bills to email out
+ * @returns The updated list of bills (successfully-emailed bills are marked as
+ * such)
+ */
+// TODO: remove this line when emailBills tests are un-skipped
+/* istanbul ignore next */
+export async function emailBills(billList: Bill[]): Promise<Bill[]> {
+    billList.forEach(async (bill) => {
+        // prevent sending duplicate emails
+        if (typeof bill.emailedBill === 'undefined') {
+            try {
+                //
+                // TODO: send the email
+                //
+                // // (gonna need to import this fn from '../database/billing')
+                // await markBillEmailed(bill.billId);
+                // // update our local copy of the bill
+                // bill.emailedBill = format(new Date(), 'yyyy-MM-dd');
+                throw new Error('sending emails is unimplemented!');
+            } catch (e) {
+                // send more emails even if this one failed
+                logger.error(`Failed to email bill ${bill.billId} to ${bill.membershipAdminEmail}: ${e}`);
+            }
+        }
+    });
+    return billList;
+}


### PR DESCRIPTION
- This ended up taking quite a bit of refactoring for the billing API (the generation endpoint in particular).
  - There are two new helper functions for the generation endpoint in the utils: `generateNewBills` and `emailBills`.
  - The `emailBills` function is incomplete since we don't email bills yet.
    - Its tests are currently incomplete and **skipped**, and the function itself is excluded from code coverage, until it's fully implemented.
    - There are TODOs all over the place that should illustrate what to do upon implementation.
- The backend unit test coverage is back up to 97.19%, with 100% for the three files I added tests for.

Closes #245 